### PR TITLE
Fix Error if Every Player has Creator Points

### DIFF
--- a/tools/cron/fixcps.php
+++ b/tools/cron/fixcps.php
@@ -120,9 +120,11 @@ foreach($result as $daily){
 	DONE
 */
 $nocpppl = substr($nocpppl, 0, -1);
-$query4 = $db->prepare("UPDATE users SET creatorPoints = 0 WHERE userID IN ($nocpppl)");
-$query4->execute();
-echo "Reset CP of $nocpppl <br>";
+if ($nocpppl != "") {
+	$query4 = $db->prepare("UPDATE users SET creatorPoints = 0 WHERE userID IN ($nocpppl)");
+	$query4->execute();
+	echo "Reset CP of $nocpppl <br>";
+}
 foreach($people as $user => $cp){
 	echo "$user now has $cp creator points... <br>";
 	ob_flush();


### PR DESCRIPTION
For Issue #343 
Fix SQL error if every player without exception has creator points. $nocpppl will be empty and brakes the query. So, if everyone has Creator Points, this query shouldn't be executed.