### PR TITLE
fix SHOWING RESULT FOR $str in userLevelSearchBot

### DIFF
--- a/tools/bot/userLevelSearchBot.php
+++ b/tools/bot/userLevelSearchBot.php
@@ -5,7 +5,7 @@ require_once "../../incl/lib/exploitPatch.php";
 $ep = new exploitPatch();
 require_once "../../incl/lib/mainLib.php";
 $gs = new mainLib();
-$str = $ep->remove($_POST["str"]);
+$str = $ep->remove($_GET["str"]);
 $difficulty = "";
 $original = "";
 //getting level data


### PR DESCRIPTION
of course this code still doesn't work but I fixed SHOWING RESULT FOR $str bug, which wasn't view str value
*sorry for my english* and Cvolton please fix bug, which API doesn't show level even if you put correct nickname with more than 1 levels