### PR TITLE
Fixed some overrides

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -830,7 +830,7 @@ ALTER TABLE `gauntlets`
 -- AUTO_INCREMENT for table `levels`
 --
 ALTER TABLE `levels`
-  MODIFY `levelID` int(11) NOT NULL AUTO_INCREMENT;
+  MODIFY `levelID` int(11) NOT NULL, AUTO_INCREMENT = 22;
 
 --
 -- AUTO_INCREMENT for table `levelscores`
@@ -908,7 +908,7 @@ ALTER TABLE `roles`
 -- AUTO_INCREMENT for table `songs`
 --
 ALTER TABLE `songs`
-  MODIFY `ID` int(11) NOT NULL AUTO_INCREMENT;
+  MODIFY `ID` int(11) NOT NULL, AUTO_INCREMENT = 5000000;
 
 --
 -- AUTO_INCREMENT for table `suggest`


### PR DESCRIPTION
Levels can override official levels. Songs can override Newgrounds songs. It can be annoying, but I've got the solution! A pull request! I tried this in August, but I was a noob at SQL so it wasn't gonna work. I redid it today and some online syntax checks got to the result. I feel this is going to be useful for many people. Alright, I'm out.