### PR TITLE
suggestGJStars tweak

### DIFF
--- a/incl/levels/suggestGJStars.php
+++ b/incl/levels/suggestGJStars.php
@@ -26,12 +26,12 @@ if($accountID != "" AND $gjp != ""){
 			$gs->suggestLevel($accountID, $levelID, $difficulty["diff"], $stars, $feature, $difficulty["auto"], $difficulty["demon"]);
 			echo 1;
 		}else{
-			echo -1;
+			echo -2;
 		}
 	}else{
-		echo -1;
+		echo -2;
 	}
 }else{
-	echo -1;
+	echo -2;
 }
 ?>


### PR DESCRIPTION
removes the mod button if you lack the permissions to rate or suggest stars.

for those wondering how this is any different, the client checks for -2 in its response and if you get -2, the mod button is removed, there isn't any checks for a -1 response so the usual -1 doesnt remove it