### PR TITLE
Account linking compability and updated user info for levelReupload.php

### DIFF
--- a/config/reuploadAcc.php
+++ b/config/reuploadAcc.php
@@ -1,0 +1,10 @@
+$reupUID = 71; // The UserID of the account.
+$reupAID = 71; // The AccountID of the account. Also known as extID in the "users" table.
+
+/*
+  Setup for the reupload account:
+  Create a new account on the GDPS and edit the UserID and AccountID accordingly
+  in the users table. 
+  
+  Image example of getting the IDs can be found here: http://i.ryadev.xyz/f3qu3.png
+*/

--- a/config/reuploadAcc.php
+++ b/config/reuploadAcc.php
@@ -1,3 +1,4 @@
+<?php
 $reupUID = 71; // The UserID of the account.
 $reupAID = 71; // The AccountID of the account. Also known as extID in the "users" table.
 
@@ -8,3 +9,4 @@ $reupAID = 71; // The AccountID of the account. Also known as extID in the "user
   
   Image example of getting the IDs can be found here: http://i.ryadev.xyz/f3qu3.png
 */
+?>

--- a/tools/levelReupload.php
+++ b/tools/levelReupload.php
@@ -15,6 +15,7 @@ function chkarray($source){
 //error_reporting(0);
 include "../incl/lib/connection.php";
 require "../incl/lib/XORCipher.php";
+require "../config/reuploadAcc.php";
 $xc = new XORCipher();
 if(!empty($_POST["levelid"])){
 	$levelID = $_POST["levelid"];
@@ -111,8 +112,8 @@ if(!empty($_POST["levelid"])){
 			$query = $db->prepare("SELECT accountID, userID FROM links WHERE targetUserID=:target AND server=:url");
 			$query->execute([':target' => $targetUserID, ':url' => $parsedurl["host"]]);
 			if($query->rowCount() == 0){
-				$userID = 0;
-				$extID = 0;
+				$userID = $reupUID;
+				$extID = $reupAID;
 			}else{
 				$userInfo = $query->fetchAll()[0];
 				$userID = $userInfo["userID"];

--- a/tools/levelReupload.php
+++ b/tools/levelReupload.php
@@ -108,11 +108,11 @@ if(!empty($_POST["levelid"])){
 			}
 			$targetUserID = chkarray($levelarray["a6"]);
 			//linkacc
-			$query = $db->prepare("SELECT accountID, userID FROM links WHERE targetUserID=:target");
-			$query->execute([':target' => $targetUserID]);
+			$query = $db->prepare("SELECT accountID, userID FROM links WHERE targetUserID=:target AND server=:url");
+			$query->execute([':target' => $targetUserID, ':url' => $parsedurl["host"]]);
 			if($query->rowCount() == 0){
-				$userID = 388;
-				$extID = 263;
+				$userID = 0;
+				$extID = 0;
 			}else{
 				$userInfo = $query->fetchAll()[0];
 				$userID = $userInfo["userID"];


### PR DESCRIPTION
What? Never knew that you can link your account with multiple servers? You always could!!!!!
(That is if you weren't using it to reupload levels..)

This super lazy fix will now properply check account linkings depending on the url, thus avoiding multiple results showing up INCASE there are multiple targetUserID listed up.
Also replaced the hardcoded UserID with a configurateable variable, set to RobTop's special UserID by default because a few people are aware what use this ID has.