### PR TITLE
getGJTopArtists.php with proper functionality

### DIFF
--- a/config/topArtists.php
+++ b/config/topArtists.php
@@ -1,0 +1,8 @@
+<?php
+$redirect = 0;
+/*
+	Indicates wether the server should ask the main GD servers for the top artists list or not.
+	If it's 0, it will fetch the most commonly used songs on the server by artists and list such up.
+	If it's 1, it will ask the main servers for the list (which is not actively maintained).
+*/
+?>

--- a/getGJTopArtists.php
+++ b/getGJTopArtists.php
@@ -1,1 +1,3 @@
-4:This server is based on|4:CvoltonGDPS|4:See github.com/cvolton/GMDprivateServer#3:0:20
+<?php
+include "incl/misc/getTopArtists.php";
+?>

--- a/incl/misc/getTopArtists.php
+++ b/incl/misc/getTopArtists.php
@@ -28,12 +28,12 @@ if($redirect == 1) {
 	echo $result;
 } else {
 	// select
-	$querywhat = "SELECT authorName FROM songs WHERE (authorName NOT LIKE '%Reupload%') GROUP BY authorName ORDER BY COUNT(authorName) DESC LIMIT 20 OFFSET $offset"; // offset couldn't be used in prepare statement for some very odd reason
+	$querywhat = "SELECT authorName FROM songs WHERE (authorName NOT LIKE '%Reupload%' AND authorName NOT LIKE 'unknown') GROUP BY authorName ORDER BY COUNT(authorName) DESC LIMIT 20 OFFSET $offset"; // offset couldn't be used in prepare statement for some very odd reason
 	$query = $db->prepare($querywhat);
 	$query->execute();
 	$res = $query->fetchAll();
 	// count
-	$countquery = $db->prepare("SELECT count(DISTINCT(authorName)) FROM songs WHERE (authorName NOT LIKE '%Reupload%')");
+	$countquery = $db->prepare("SELECT count(DISTINCT(authorName)) FROM songs WHERE (authorName NOT LIKE '%Reupload%' AND authorName NOT LIKE 'unknown')");
 	$countquery->execute();
 	$totalCount = $countquery->fetchColumn();
 	// parse

--- a/incl/misc/getTopArtists.php
+++ b/incl/misc/getTopArtists.php
@@ -1,0 +1,48 @@
+<?php
+chdir(dirname(__FILE__));
+require "../lib/connection.php";
+require "../lib/exploitPatch.php";
+require "../../config/topArtists.php";
+$ep = new exploitPatch();
+$str = "";
+
+if(isset($_POST["page"]) AND is_numeric($_POST["page"])){
+	$offset = $ep->number($_POST["page"]) . "0";
+	$offset = $offset*2; // ask robtop
+}else{
+	$offset = 0;
+}
+
+if($redirect == 1) {
+	// parse
+	$url = "http://boomlings.com/database/getGJTopArtists.php";
+	$request = "page=$offset&secret=Wmfd2893gb7";
+	parse_str($request, $post);
+	// post
+	$ch = curl_init($url);
+	curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	$result = curl_exec($ch);
+	curl_close($ch);
+	// send result
+	echo $result;
+} else {
+	// select
+	$querywhat = "SELECT authorName FROM songs WHERE (authorName NOT LIKE '%Reupload%') GROUP BY authorName ORDER BY COUNT(authorName) DESC LIMIT 20 OFFSET $offset"; // offset couldn't be used in prepare statement for some very odd reason
+	$query = $db->prepare($querywhat);
+	$query->execute();
+	$res = $query->fetchAll();
+	// count
+	$countquery = $db->prepare("SELECT count(DISTINCT(authorName)) FROM songs WHERE (authorName NOT LIKE '%Reupload%')");
+	$countquery->execute();
+	$totalCount = $countquery->fetchColumn();
+	// parse
+	foreach($res as $name){
+		$str .= "4:$name[0]|";
+	}
+	$str = rtrim($str, "|");
+	$str .= "#$totalCount:$offset:20";
+	// send result
+	echo "$str";
+}
+?>

--- a/incl/misc/getTopArtists.php
+++ b/incl/misc/getTopArtists.php
@@ -28,9 +28,8 @@ if($redirect == 1) {
 	echo $result;
 } else {
 	// select
-	$querywhat = "SELECT authorName FROM songs WHERE (authorName NOT LIKE '%Reupload%') GROUP BY authorName ORDER BY COUNT(authorName) DESC LIMIT 20 OFFSET $offset"; // offset couldn't be used in prepare statement for some very odd reason
-	$query = $db->prepare($querywhat);
-	$query->execute();
+	$query = $db->prepare("SELECT authorName FROM songs WHERE (authorName NOT LIKE '%Reupload%') GROUP BY authorName ORDER BY COUNT(authorName) DESC LIMIT 20 OFFSET :off");
+	$query->execute([':off' => $offset]);
 	$res = $query->fetchAll();
 	// count
 	$countquery = $db->prepare("SELECT count(DISTINCT(authorName)) FROM songs WHERE (authorName NOT LIKE '%Reupload%')");

--- a/incl/misc/getTopArtists.php
+++ b/incl/misc/getTopArtists.php
@@ -28,8 +28,9 @@ if($redirect == 1) {
 	echo $result;
 } else {
 	// select
-	$query = $db->prepare("SELECT authorName FROM songs WHERE (authorName NOT LIKE '%Reupload%') GROUP BY authorName ORDER BY COUNT(authorName) DESC LIMIT 20 OFFSET :off");
-	$query->execute([':off' => $offset]);
+	$querywhat = "SELECT authorName FROM songs WHERE (authorName NOT LIKE '%Reupload%') GROUP BY authorName ORDER BY COUNT(authorName) DESC LIMIT 20 OFFSET $offset"; // offset couldn't be used in prepare statement for some very odd reason
+	$query = $db->prepare($querywhat);
+	$query->execute();
 	$res = $query->fetchAll();
 	// count
 	$countquery = $db->prepare("SELECT count(DISTINCT(authorName)) FROM songs WHERE (authorName NOT LIKE '%Reupload%')");


### PR DESCRIPTION
So because you had this stuck in the #to-do-list since 2017, I (actually @Intelligent-Cat) thought of working on this finally.
![Read the title you dum](http://i.ryadev.xyz/znqg2.png)

It also comes with a config (yet another idea by @Intelligent-Cat) wether it should take the response from RobTop's server or to fetch the most common artists on the GDPS. (Shouldn't break but the `artist.newgrounds.com` links could be misleading if there are a lot of SoundCloud song reuploads.)