### PR TITLE
give elder mods perms to delete comments

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -455,6 +455,7 @@ CREATE TABLE `roles` (
   `actionRateDifficulty` int(11) NOT NULL DEFAULT 0,
   `actionRequestMod` int(11) NOT NULL DEFAULT 0,
   `actionSuggestRating` int(11) NOT NULL DEFAULT 0,
+  `actionDeleteComment` int(11) NOT NULL DEFAULT 0,
   `toolLeaderboardsban` int(11) NOT NULL DEFAULT 0,
   `toolPackcreate` int(11) NOT NULL DEFAULT 0,
   `toolQuestsCreate` int(11) NOT NULL DEFAULT 0,

--- a/incl/comments/deleteGJAccComment.php
+++ b/incl/comments/deleteGJAccComment.php
@@ -4,6 +4,8 @@ include "../lib/connection.php";
 require_once "../lib/GJPCheck.php";
 require_once "../lib/exploitPatch.php";
 $ep = new exploitPatch();
+require_once "../lib/mainLib.php"; //this is connection.php too
+$gs = new mainLib();
 $commentID = $ep->remove($_POST["commentID"]);
 $accountID = $ep->remove($_POST["accountID"]);
 $gjp = $ep->remove($_POST["gjp"]);
@@ -14,6 +16,10 @@ if($gjpresult == 1){
 	$query2->execute([':accountID' => $accountID]);
 	if ($query2->rowCount() > 0) {
 		$userID = $query2->fetchColumn();
+	}
+	if($gs->checkPermission($accountID, "actionDeleteComment") == 1) {
+		$query = $db->prepare("DELETE FROM acccomments WHERE commentID = :commentID LIMIT 1");
+		$query->execute([':commentID' => $commentID]);
 	}
 	$query = $db->prepare("DELETE FROM acccomments WHERE commentID=:commentID AND userID=:userID LIMIT 1");
 	$query->execute([':userID' => $userID, ':commentID' => $commentID]);

--- a/incl/comments/deleteGJComment.php
+++ b/incl/comments/deleteGJComment.php
@@ -4,6 +4,8 @@ include "../lib/connection.php";
 require_once "../lib/GJPCheck.php";
 require_once "../lib/exploitPatch.php";
 $ep = new exploitPatch();
+require_once "../lib/mainLib.php"; //this is connection.php too
+$gs = new mainLib();
 $commentID = $ep->remove($_POST["commentID"]);
 $accountID = $ep->remove($_POST["accountID"]);
 $gjp = $ep->remove($_POST["gjp"]);
@@ -29,6 +31,10 @@ if($gjpresult == 1){
 			$query = $db->prepare("DELETE FROM comments WHERE commentID=:commentID AND levelID=:levelID LIMIT 1");
 			$query->execute([':commentID' => $commentID, ':levelID' => $levelID]);
 		}
+		if($gs->checkPermission($accountID, "actionDeleteComment") == 1) {
+            $query = $db->prepare("DELETE FROM comments WHERE commentID = :commentID AND levelID = :levelID LIMIT 1");
+            $query->execute([':commentID' => $commentID, ':levelID' => $levelID]);
+        }
 	}
 	echo "1";
 }else{


### PR DESCRIPTION
the way this mechanic works is strange because of robtop.

to get the option to delete comments you have to click on the req button, this sets up a 'mod session' and enables the permissions for you, if you then close the game, the session has ended so comment deletion is also disabled meaning you have to click req again to enable it