### PR TITLE
Set initial AUTO_INCREMENT value of level IDs to 128

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -884,7 +884,8 @@ ALTER TABLE `gauntlets`
 -- AUTO_INCREMENT for table `levels`
 --
 ALTER TABLE `levels`
-  MODIFY `levelID` int(11) NOT NULL AUTO_INCREMENT;
+  MODIFY `levelID` int(11) NOT NULL AUTO_INCREMENT,
+  AUTO_INCREMENT=128;
 
 --
 -- AUTO_INCREMENT for table `levelscores`


### PR DESCRIPTION
Setting the first level's ID to 128 (as is the case in real GD) avoids an issue which breaks stars for levels with really low IDs (I have no idea how the bug works but I've heard it has something to do with clashing with official levels)