### PR TITLE
Added docker-compose support for quick GDPS testing setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM php:7.3-apache
+RUN docker-php-ext-install mysqli pdo_mysql
+COPY . /var/www/html/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM php:7.3-apache
 RUN docker-php-ext-install mysqli pdo_mysql
-COPY . /var/www/html/
+COPY . /var/www/html/database/

--- a/config/connection.php
+++ b/config/connection.php
@@ -1,7 +1,7 @@
 <?php
-$servername = "127.0.0.1";
+$servername = "db";
 $port = 3306;
-$username = "root";
-$password = "";
+$username = "robtop";
+$password = "geometrydash";
 $dbname = "geometrydash";
 ?>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       MYSQL_DATABASE: geometrydash
     volumes:
       - "./database.sql:/docker-entrypoint-initdb.d/database.sql:ro"
+      - "/data/gdps:/var/lib/mysql"
+      # persists the database at /data/gdps on the host machine
     expose:
       - 3306
   adminer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build: .
     ports:
       - 80:80
+    volumes:
+      # persists the levels and backups on the host machine
+      - "/etc/gdps/data:/var/www/html/database/data"
   db:
     image: mariadb
     restart: always
@@ -13,8 +16,8 @@ services:
       MYSQL_DATABASE: geometrydash
     volumes:
       - "./database.sql:/docker-entrypoint-initdb.d/database.sql:ro"
-      - "/data/gdps:/var/lib/mysql"
       # persists the database at /data/gdps on the host machine
+      - "/etc/gdps/mysql:/var/lib/mysql"
     expose:
       - 3306
   adminer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       MYSQL_USER: robtop
       MYSQL_PASSWORD: geometrydash
       MYSQL_DATABASE: geometrydash
+    volumes:
+      - "./database.sql:/docker-entrypoint-initdb.d/database.sql:ro"
     expose:
       - 3306
   adminer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  gdps:
+    build: .
+    ports:
+      - 80:80
+  db:
+    image: mariadb
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: something
+      MYSQL_USER: robtop
+      MYSQL_PASSWORD: geometrydash
+      MYSQL_DATABASE: geometrydash
+    expose:
+      - 3306
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 8080:8080


### PR DESCRIPTION
Hello @Cvolton,

today I tried setting up my own GPDS using your software and I found it was not as easy as I initially expected, even though I would call myself relatively good with software. So here I added a docker-compose.yml file for quick setup.

To create a new GDPS on your local machine just run `docker-compose up` in the project root and then you're ready to go. The database is automatically created and initialized from the repository (currently not persistent, but that can be added as a one-liner in the compose file). Instead of replacing every link in the GeometryDash.exe file I just modified my host file to point to my local machine.

I also pre-configured the database connection to point to the docker container of the database with the preset username.

There is no contribution file in the repository so I didn't know if you accept pull requests, but for me it was good to have docker support so here it is, do with it what you want.

OnlyFreeUsername