### PR TITLE
Fix an issue with registerGJAccount.php which resulted in an error 500

### DIFF
--- a/accounts/registerGJAccount.php
+++ b/accounts/registerGJAccount.php
@@ -27,8 +27,8 @@ if($_POST["userName"] != ""){
 		$hashpass = password_hash($password, PASSWORD_DEFAULT);
 		$gjp2 = GeneratePass::GJP2hash($password);
 		$query = $db->prepare("INSERT INTO accounts (userName, password, email, registerDate, isActive, gjp2)
-		VALUES (:userName, :password, :email, :time, :isActive)");
-		$query->execute([':userName' => $userName, ':password' => $hashpass, ':email' => $email, ':time' => time(), ':isActive' => $preactivateAccounts ? 1 : 0, ':gjp2' => $gjp2]);
+		VALUES (:userName, :password, :email, :time, :isActive, :gjp)");
+		$query->execute([':userName' => $userName, ':password' => $hashpass, ':email' => $email, ':time' => time(), ':isActive' => $preactivateAccounts ? 1 : 0, ':gjp' => $gjp2]);
 		echo "1";
 	}
 }


### PR DESCRIPTION
There was this issue where registerGJAccount would return a 500 error on line 31, gotten from my nginx error log.
I was running ubuntu 22.04 with the latest version of php, nginx and mariadb while testing it out

Apparently this fixes it, so I'm just putting it here as a fix can't hurt