### PR TITLE
Update userinfo in 1.0 - 1.21

### DIFF
--- a/incl/levels/uploadGJLevel.php
+++ b/incl/levels/uploadGJLevel.php
@@ -64,7 +64,7 @@ $settingsString = !empty($_POST["settingsString"]) ? ExploitPatch::remove($_POST
 if(isset($_POST["password"])){
 	$password = ExploitPatch::remove($_POST["password"]);
 }else{
-	$password = 1;
+	$password = 0;
 	if($gameVersion > 17){
 		$password = 0;
 	}
@@ -74,13 +74,12 @@ $hostname = $gs->getIP();
 $userID = $mainLib->getUserID($id, $userName);
 $uploadDate = time();
 $query = $db->prepare("SELECT count(*) FROM levels WHERE uploadDate > :time AND (userID = :userID OR hostname = :ip)");
-$query->execute([':time' => $uploadDate - 60, ':userID' => $userID, ':ip' => $hostname]);
+$query->execute([':time' => $uploadDate - 120, ':userID' => $userID, ':ip' => $hostname]);
 if($query->fetchColumn() > 0){
 	exit("-1");
 }
 $query = $db->prepare("INSERT INTO levels (levelName, gameVersion, binaryVersion, userName, levelDesc, levelVersion, levelLength, audioTrack, auto, password, original, twoPlayer, songID, objects, coins, requestedStars, extraString, levelString, levelInfo, secret, uploadDate, userID, extID, updateDate, unlisted, hostname, isLDM, wt, wt2, unlisted2, settingsString)
 VALUES (:levelName, :gameVersion, :binaryVersion, :userName, :levelDesc, :levelVersion, :levelLength, :audioTrack, :auto, :password, :original, :twoPlayer, :songID, :objects, :coins, :requestedStars, :extraString, :levelString, :levelInfo, :secret, :uploadDate, :userID, :id, :uploadDate, :unlisted, :hostname, :ldm, :wt, :wt2, :unlisted2, :settingsString)");
-
 
 if($levelString != "" AND $levelName != ""){
 	$querye=$db->prepare("SELECT levelID FROM levels WHERE levelName = :levelName AND userID = :userID");
@@ -97,7 +96,13 @@ if($levelString != "" AND $levelName != ""){
 		$levelID = $db->lastInsertId();
 		file_put_contents("../../data/levels/$levelID",$levelString);
 		echo $levelID;
+		
+
 	}
+
+$query = $db->prepare("UPDATE users SET gameVersion=:gameVersion, userName=:userName, secret=:secret, IP=:hostname, lastPlayed=:uploadDate WHERE userID=:userID");
+$query->execute([':gameVersion' => $gameVersion, ':userName' => $userName, ':secret' => $secret, ':hostname' => $hostname, ':uploadDate' => $uploadDate, ':userID' => $userID]);
+
 }else{
 	echo -1;
 }

--- a/incl/levels/uploadGJLevel.php
+++ b/incl/levels/uploadGJLevel.php
@@ -64,7 +64,7 @@ $settingsString = !empty($_POST["settingsString"]) ? ExploitPatch::remove($_POST
 if(isset($_POST["password"])){
 	$password = ExploitPatch::remove($_POST["password"]);
 }else{
-	$password = 0;
+	$password = 1;
 	if($gameVersion > 17){
 		$password = 0;
 	}
@@ -74,7 +74,7 @@ $hostname = $gs->getIP();
 $userID = $mainLib->getUserID($id, $userName);
 $uploadDate = time();
 $query = $db->prepare("SELECT count(*) FROM levels WHERE uploadDate > :time AND (userID = :userID OR hostname = :ip)");
-$query->execute([':time' => $uploadDate - 120, ':userID' => $userID, ':ip' => $hostname]);
+$query->execute([':time' => $uploadDate - 60, ':userID' => $userID, ':ip' => $hostname]);
 if($query->fetchColumn() > 0){
 	exit("-1");
 }
@@ -96,8 +96,6 @@ if($levelString != "" AND $levelName != ""){
 		$levelID = $db->lastInsertId();
 		file_put_contents("../../data/levels/$levelID",$levelString);
 		echo $levelID;
-		
-
 	}
 
 $query = $db->prepare("UPDATE users SET gameVersion=:gameVersion, userName=:userName, secret=:secret, IP=:hostname, lastPlayed=:uploadDate WHERE userID=:userID");


### PR DESCRIPTION
Due to the fact that in versions 1.0 - 1.21 there was no updateGJUserScore.php in the game, it was impossible to change the nickname, update the lastplayed time, etc. Now these functions work when you upload a level: updating gameversion, updating username, post secret, update ip, update lastplayed time.