### PR TITLE
Add proper RobTop-like timestamps (configurable)

### DIFF
--- a/config/timestamps.php
+++ b/config/timestamps.php
@@ -1,0 +1,8 @@
+<?php
+$timestampsMode = 0;
+/*
+    Indicates how timestamps are given to the game and bots.
+    0 = Send timestamps with the following format: "{Number} {Highest time the timestamp is divisible by} ago".
+    1 = Send timestamps as dates.
+*/
+?>

--- a/incl/comments/getGJAccountComments.php
+++ b/incl/comments/getGJAccountComments.php
@@ -5,6 +5,7 @@ include "../lib/connection.php";
 require_once "../lib/exploitPatch.php";
 require_once "../lib/mainLib.php";
 $gs = new mainLib();
+include "../../config/timestamps.php";
 $commentstring = "";
 $accountid = ExploitPatch::remove($_POST["accountID"]);
 $page = ExploitPatch::remove($_POST["page"]);
@@ -22,7 +23,11 @@ $countquery->execute([':userID' => $userID]);
 $commentcount = $countquery->fetchColumn();
 foreach($result as &$comment1) {
 	if($comment1["commentID"]!=""){
-		$uploadDate = date("d/m/Y G:i", $comment1["timestamp"]);
+		if ($timestampsMode == 0) {
+			$uploadDate = $gs->makeTime($comment1["timestamp"]);
+		} else {
+			$uploadDate = date("d/m/Y G:i", $comment1["timestamp"]);
+		}
 		$commentstring .= "2~".$comment1["comment"]."~3~".$comment1["userID"]."~4~".$comment1["likes"]."~5~0~7~".$comment1["isSpam"]."~9~".$uploadDate."~6~".$comment1["commentID"]."|";
 	}
 }

--- a/incl/comments/getGJComments.php
+++ b/incl/comments/getGJComments.php
@@ -5,6 +5,7 @@ include "../lib/connection.php";
 require_once "../lib/exploitPatch.php";
 require_once "../lib/mainLib.php";
 $gs = new mainLib();
+include "../../config/timestamps.php";
 
 $commentstring = "";
 $userstring = "";
@@ -57,7 +58,11 @@ $visiblecount = $query->rowCount();
 
 foreach($result as &$comment1) {
 	if($comment1["commentID"]!=""){
-		$uploadDate = date("d/m/Y G.i", $comment1["timestamp"]);
+		if ($timestampsMode == 0) {
+			$uploadDate = $gs->makeTime($comment1["timestamp"]);
+		} else {
+			$uploadDate = date("d/m/Y G.i", $comment1["timestamp"]);
+		}
 		$commentText = ($gameVersion < 20) ? base64_decode($comment1["comment"]) : $comment1["comment"];
 		if($displayLevelID) $commentstring .= "1~".$comment1["levelID"]."~";
 		$commentstring .= "2~".$commentText."~3~".$comment1["userID"]."~4~".$comment1["likes"]."~5~0~7~".$comment1["isSpam"]."~9~".$uploadDate."~6~".$comment1["commentID"]."~10~".$comment1["percent"];

--- a/incl/levels/downloadGJLevel.php
+++ b/incl/levels/downloadGJLevel.php
@@ -7,6 +7,7 @@ require_once "../lib/mainLib.php";
 $gs = new mainLib();
 require "../lib/generateHash.php";
 require "../lib/GJPCheck.php";
+include "../../config/timestamps.php";
 if(empty($_POST["gameVersion"])){
 	$gameVersion = 1;
 }else{
@@ -78,13 +79,17 @@ if(!is_numeric($levelID)){
 		if($inc && $query6->fetchColumn() < 2){
 			$query2=$db->prepare("UPDATE levels SET downloads = downloads + 1 WHERE levelID = :levelID");
 			$query2->execute([':levelID' => $levelID]);
-			$query6 = $db->prepare("INSERT INTO actions_downloads (levelID, ip) VALUES 
-														(:levelID,INET6_ATON(:ip))");
+			$query6 = $db->prepare("INSERT INTO actions_downloads (levelID, ip) VALUES (:levelID,INET6_ATON(:ip))");
 			$query6->execute([':levelID' => $levelID, ':ip' => $ip]);
 		}
-		//getting the days since uploaded... or outputting the date in Y-M-D format at least for now...
-		$uploadDate = date("d-m-Y G-i", $result["uploadDate"]);
-		$updateDate = date("d-m-Y G-i", $result["updateDate"]);
+		// getting time since uploaded and updated and formatting them...
+		if ($timestampsMode == 0) {
+			$uploadDate = $gs->makeTime($result["uploadDate"]);
+			$updateDate = $gs->makeTime($result["updateDate"]);
+		} else {
+			$uploadDate = date("d-m-Y G-i", $result["uploadDate"]);
+			$updateDate = date("d-m-Y G-i", $result["updateDate"]);
+		}
 		//password xor
 		$pass = $result["password"];
 		$desc = $result["levelDesc"];

--- a/incl/lib/mainLib.php
+++ b/incl/lib/mainLib.php
@@ -210,57 +210,15 @@ class mainLib {
 			return $gauntlets[0];
 		return $gauntlets[$id];
 	}
-
-	function makeTime($delta)
-	{
-		if ($delta < 31536000)
-		{
-			if ($delta < 2628000)
-			{
-				if ($delta < 604800)
-				{
-					if ($delta < 86400)
-					{
-						if ($delta < 3600)
-						{
-							if ($delta < 60)
-							{
-								return $delta." second".($delta == 1 ? "" : "s");
-							}
-							else
-							{
-                        					$rounded = floor($delta / 60);
-								return $rounded." minute".($rounded == 1 ? "" : "s");
-							}
-						}
-						else
-						{
-							$rounded = floor($delta / 3600);
-							return $rounded." hour".($rounded == 1 ? "" : "s");
-						}
-					}
-					else
-					{
-						$rounded = floor($delta / 86400);
-						return $rounded." day".($rounded == 1 ? "" : "s");
-					}
-				}
-				else
-				{
-					$rounded = floor($delta / 604800);
-					return $rounded." week".($rounded == 1 ? "" : "s");
-				}
-			}
-			else
-			{
-				$rounded = floor($delta / 2628000); 
-				return $rounded." month".($rounded == 1 ? "" : "s");
-			}
-		}
-		else
-		{
-			$rounded = floor($delta / 31536000);
-			return $rounded." year".($rounded == 1 ? "" : "s");
+	public function makeTime($time) {
+		// taken from https://stackoverflow.com/a/36297417
+		$time = time() - $time; // to get the time since that moment
+		$time = ($time < 1) ? 1 : $time; // ternary operator
+		$tokens = array (31536000 => 'year', 2592000 => 'month', 604800 => 'week', 86400 => 'day', 3600 => 'hour', 60 => 'minute', 1 => 'second');
+		foreach ($tokens as $unit => $text) {
+			if ($time < $unit) continue;
+			$numberOfUnits = floor($time / $unit);
+			return $numberOfUnits . ' ' . $text . (($numberOfUnits > 1) ? 's' : '');
 		}
 	}
 	public function getIDFromPost(){

--- a/incl/messages/downloadGJMessage.php
+++ b/incl/messages/downloadGJMessage.php
@@ -3,6 +3,9 @@ chdir(dirname(__FILE__));
 include "../lib/connection.php";
 require_once "../lib/GJPCheck.php";
 require_once "../lib/exploitPatch.php";
+require_once "../lib/mainLib.php";
+$gs = new mainLib();
+include "../../config/timestamps.php";
 
 $accountID = GJPCheck::getAccountIDOrDie();
 $messageID = ExploitPatch::remove($_POST["messageID"]);
@@ -25,6 +28,10 @@ if(empty($_POST["isSender"])){
 $query=$db->prepare("SELECT userName,userID,extID FROM users WHERE extID = :accountID");
 $query->execute([':accountID' => $accountID]);
 $result12 = $query->fetch();
-$uploadDate = date("d/m/Y G.i", $result["timestamp"]);
+if ($timestampsMode == 0) {
+	$uploadDate = $gs->makeTime($result["timestamp"]);
+} else {
+	$uploadDate = date("d/m/Y G.i", $result["timestamp"]);
+}
 echo "6:".$result12["userName"].":3:".$result12["userID"].":2:".$result12["extID"].":1:".$result["messageID"].":4:".$result["subject"].":8:".$result["isNew"].":9:".$isSender.":5:".$result["body"].":7:".$uploadDate."";
 ?>

--- a/incl/messages/getGJMessages.php
+++ b/incl/messages/getGJMessages.php
@@ -1,9 +1,11 @@
 <?php
 chdir(dirname(__FILE__));
-//error_reporting(0);
 include "../lib/connection.php";
 require_once "../lib/GJPCheck.php";
 require_once "../lib/exploitPatch.php";
+require_once "../lib/mainLib.php";
+$gs = new mainLib();
+include "../../config/timestamps.php";
 $msgstring = "";
 //code begins
 $toAccountID = GJPCheck::getAccountIDOrDie();
@@ -29,8 +31,12 @@ if($msgcount == 0){
 	exit("-2");
 }
 foreach ($result as &$message1) {
-	if($message1["messageID"]!=""){
-		$uploadDate = date("d/m/Y G.i", $message1["timestamp"]);
+	if($message1["messageID"] != ""){
+		if ($timestampsMode == 0) {
+			$uploadDate = $gs->makeTime($message1["timestamp"]);
+		} else {
+			$uploadDate = date("d/m/Y G.i", $message1["timestamp"]);
+		}
 		if($getSent == 1){
 			$accountID = $message1["toAccountID"];
 		}else{

--- a/incl/profiles/getGJUserInfo.php
+++ b/incl/profiles/getGJUserInfo.php
@@ -87,7 +87,11 @@ if($me==$extid){
 		$INCrequests = $query->rowCount();
 		$INCrequestinfo = $query->fetch();
 		if($INCrequests > 0){
-			$uploaddate = date("d/m/Y G.i", $INCrequestinfo["uploadDate"]);
+			if ($timestampsMode == 0) {
+				$uploaddate = $gs->makeTime($INCrequestinfo["uploadDate"]);
+			} else {
+				$uploaddate = date("d/m/Y G.i", $INCrequestinfo["uploadDate"]);
+			}
 			$friendstate=3;
 		}
 	//check if OUTCOMING friend request

--- a/incl/relationships/getGJFriendRequests.php
+++ b/incl/relationships/getGJFriendRequests.php
@@ -3,6 +3,9 @@ chdir(dirname(__FILE__));
 include "../lib/connection.php";
 require_once "../lib/exploitPatch.php";
 require_once "../lib/GJPCheck.php";
+require_once "../lib/mainLib.php";
+$gs = new mainLib();
+include "../../config/timestamps.php";
 $reqstring = "";
 $getSent = !empty($_POST["getSent"]) ? ExploitPatch::remove($_POST["getSent"]) : 0;
 if(empty($_POST["accountID"]) OR (!isset($_POST["page"]) OR !is_numeric($_POST["page"])) OR empty($_POST["gjp"])){
@@ -40,7 +43,11 @@ foreach($result as &$request) {
 	$query->execute([':requester' => $requester]);
 	$result2 = $query->fetchAll();
 	$user = $result2[0];
-	$uploadTime = date("d/m/Y G.i", $request["uploadDate"]);
+	if ($timestampsMode == 0) {
+		$uploadTime = $gs->makeTime($request["uploadDate"]);
+	} else {
+		$uploadTime = date("d/m/Y G.i", $request["uploadDate"]);
+	}
 	if(is_numeric($user["extID"])){
 		$extid = $user["extID"];
 	}else{

--- a/incl/scores/getGJLevelScores.php
+++ b/incl/scores/getGJLevelScores.php
@@ -7,6 +7,7 @@ require_once "../lib/exploitPatch.php";
 require_once "../lib/XORCipher.php";
 require_once "../lib/mainLib.php";
 $gs = new mainLib();
+include "../../config/timestamps.php";
 
 $accountID = GJPCheck::getAccountIDOrDie();
 $levelID = ExploitPatch::remove($_POST["levelID"]);
@@ -43,8 +44,6 @@ if($percent > 100){
 	$query->execute([':accountID' => $accountID]);
 }
 
-
-
 //GETTING SCORES
 if(!isset($_POST["type"])){
 	$type = 1;
@@ -72,8 +71,6 @@ switch($type){
 		break;
 }
 
-
-
 $query2->execute($query2args);
 $result = $query2->fetchAll();
 foreach ($result as &$score) {
@@ -82,7 +79,11 @@ foreach ($result as &$score) {
 	$query2->execute([':extID' => $extID]);
 	$user = $query2->fetchAll();
 	$user = $user[0];
-	$time = date("d/m/Y G.i", $score["uploadDate"]);
+	if ($timestampsMode == 0) {
+		$time = $gs->makeTime($score["uploadDate"]);
+	} else {
+		$time = date("d/m/Y G.i", $score["uploadDate"]);
+	}
 	if($user["isBanned"]==0){
 		if($score["percent"] == 100){
 			$place = 1;


### PR DESCRIPTION
meh it probably won't get merged

This PR adds in proper RobTop-like timestamps for messages, friend requests, level uploads, etc.
You can choose to use the old date formatting by going to config/timestamps.php and setting $timestampsMode to 1

On the technical side of stuff, I reworked the unused makeTime function inside incl/lib/mainLib.php which I assumed was made and then abandoned for the purpose of RobTop-like timestamps.
I also made some small styling changes like removing weird new line gaps or deleting commented out debugging code and added in some spaces between characters to make it more readable if you don't mind.