### PR TITLE
fix an error with daily chests

### DIFF
--- a/incl/rewards/getGJRewards.php
+++ b/incl/rewards/getGJRewards.php
@@ -5,7 +5,7 @@ include "../lib/connection.php";
 include "../../config/dailyChests.php";
 require "../lib/XORCipher.php";
 require "../lib/GJPCheck.php";
-require "../lib/mainLib.php";
+require_once "../lib/mainLib.php";
 $gs = new mainLib();
 require "../lib/generateHash.php";
 require_once "../lib/exploitPatch.php";


### PR DESCRIPTION
this returns an error on my linux server and all crystalcloud gdpses
specifically, it returns something like "mainLib has already been declared"