### PR TITLE
Remove unnecessary execute args in getGJCreators

### DIFF
--- a/incl/scores/getGJCreators.php
+++ b/incl/scores/getGJCreators.php
@@ -7,7 +7,7 @@ $accountID = ExploitPatch::remove($_POST["accountID"]);
 $type = ExploitPatch::remove($_POST["type"]);
 $query = "SELECT * FROM users WHERE isCreatorBanned = '0' ORDER BY creatorPoints DESC LIMIT 100";
 $query = $db->prepare($query);
-$query->execute([':stars' => $stars, ':count' => $count]);
+$query->execute();
 $result = $query->fetchAll();
 foreach($result as &$user){
 	if(is_numeric($user["extID"])){


### PR DESCRIPTION
there's no stars or count variable in this script