### PR TITLE
Comment Permaban (-10 Implementation in uploadGJComment)

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -157,6 +157,18 @@ CREATE TABLE `comments` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `comment_bans`
+--
+
+CREATE TABLE `comment_bans` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `accountID` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `cpshares`
 --
 

--- a/incl/comments/uploadGJComment.php
+++ b/incl/comments/uploadGJComment.php
@@ -13,12 +13,21 @@ $comment = ExploitPatch::remove($_POST['comment']);
 $comment = ($gameVersion < 20) ? base64_encode($comment) : $comment;
 $levelID = ExploitPatch::number($_POST["levelID"]);
 $percent = !empty($_POST["percent"]) ? ExploitPatch::remove($_POST["percent"]) : 0;
+$accountID = !empty($_POST['accountID']) ? ExploitPatch::number($_POST['accountID']) : "";
 
 $id = $mainLib->getIDFromPost();
 $register = is_numeric($id);
 $userID = $mainLib->getUserID($id, $userName);
 $uploadDate = time();
 $decodecomment = base64_decode($comment);
+
+$checkCommentBan = $db->prepare("SELECT * FROM comment_bans WHERE accountID = :accountID");
+$checkCommentBan->execute([':accountID' => $accountID]);
+
+if ($checkCommentBan->rowCount() > 0) {
+    die("-10");
+}
+
 if(Commands::doCommands($id, $decodecomment, $levelID)){
 	exit($gameVersion > 20 ? "temp_0_Command executed successfully!" : "-1");
 }


### PR DESCRIPTION
# What is a "Comment Permaban"
RobTop never uses this to my knowledge but if you comment on a level and get the Error Code "-10", That means YOU, Yes YOU will be met with a permaban screen.  
  
Some of y'all don't even know this exists but heres what it looks like:
![image](https://github.com/Cvolton/GMDprivateServer/assets/91027492/df6ddc53-98a2-4a9b-b43e-eb05084c336b)
## How to use this code for the Pull Request?
Theres a brand new SQL table called `comment_bans` for accountIDs you want to permanently ban from your GDPS if they commented horrible things like "this level sucks, die!", "cvolton is a horrible programmer" or the worst of all: "skibidi toilet fanum tax rizzler ohio poop xDD".  
  
Since this won't be used in GD, I thought this would be used for Private Servers.
### Theres not too much to document on this really, I discovered this months ago through me looking at strings inside GeometryDash.exe and later found it through GDDocs, why did RobTop not use this?